### PR TITLE
Focaltech dts fixes

### DIFF
--- a/arch/arm64/boot/dts/qcom/pyxis-cosmos-sdm710-common.dtsi
+++ b/arch/arm64/boot/dts/qcom/pyxis-cosmos-sdm710-common.dtsi
@@ -187,9 +187,12 @@
 		focaltech,reset-when-resume;
 		focaltech,lockdown-info-addr = <0x1E000>;
 		focaltech,open-min = <2700>;
-		pinctrl-names = "pmx_ts_active", "pmx_ts_suspend";
+		pinctrl-names = "pmx_ts_active",
+				"pmx_ts_suspend",
+				"pmx_ts_release";
 		pinctrl-0 = <&ts_active>;
 		pinctrl-1 = <&ts_int_suspend &ts_reset_suspend>;
+		pinctrl-2 = <&ts_int_suspend &ts_reset_suspend>;
 		/* focaltech,have-key; */
 	};
 

--- a/arch/arm64/boot/dts/qcom/pyxis-cosmos-sdm710-common.dtsi
+++ b/arch/arm64/boot/dts/qcom/pyxis-cosmos-sdm710-common.dtsi
@@ -45,7 +45,7 @@
 	config {
 		pins = "gpio125";
 		drive-strength = <16>;
-		bias-diable;
+		bias-disable;
 		input-enable;
 	};
 


### PR DESCRIPTION
The series adds missing pinctrl for release state for focaltech_touch driver on pyxis device and fixes typo in its suspend pinctrl state.
Tested on pyxis.